### PR TITLE
[Feature] Support for ignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ webpack --json | webpack-unused
 
 # if your source code is in a directory, like src/ pass that as a flag:
 webpack --json | webpack-unused -s src
+
+# if your you want to ignore some files that are not used by webpack - like specs you can pass ignore flag (glob):
+webpack --json | webpack-unused -s src -i **/*.spec.js
+
+# or even multiple glob patterns:
+webpack --json | webpack-unused -s src -i '**/*.spec.js, lib/*.js'
 ```
 
 ## Notes/Caveats:

--- a/index.js
+++ b/index.js
@@ -17,12 +17,18 @@ const argv = require('yargs')
               .alias('s', 'src')
               .describe('s', 'Directory of source code')
               .default('s', '.')
+              .alias('i', 'ignore')
+              .describe('i', 'Ignore pattern')
+              .default('i', '')
               .help('h')
               .alias('h', 'help')
               .argv;
 
 // specify which directory to look in for source files
 const srcDir = Path.resolve(argv.src);
+
+// specify ignore pattern(s)
+const ignorePattern = argv.ignore.split(', ');
 
 const isWebpackLocal = (path) => {
   return (path.indexOf('./') === 0 && path.indexOf('./~/') === -1);
@@ -34,7 +40,7 @@ const selectLocalModules = (webpack) => {
 };
 
 const findAllLocalFiles = (cwd) => {
-  return Glob2('!(node_modules)/**/*.*', { cwd: srcDir })
+  return Glob2('!(node_modules)/**/*.*', { cwd: srcDir, ignore: ignorePattern })
           .then((files) => files.map((f) => Path.join(srcDir, f)));
 };
 


### PR DESCRIPTION
I needed support for `ignore` same as in https://github.com/latentflip/webpack-unused/issues/4

This PR is adding this feature. You can pass now `-i/ignore GLOB_PATTERNS`
