### PR TITLE
Remove unused declaration of Glob

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@
 const Path = require('path');
 const Promisify = require('es6-promisify');
 const Glob2 = Promisify(require('glob'));
-const Glob = require('glob');
 
 // webpack root? ideally start from package.json location I think
 const cwd = process.cwd();


### PR DESCRIPTION
Only the promisified version of glob is being used (stored in `Glob2`). The variable in `Glob` is defined but never used.